### PR TITLE
Add PlacementFormData id field

### DIFF
--- a/src/components/PlacementForm.tsx
+++ b/src/components/PlacementForm.tsx
@@ -2,51 +2,11 @@ import React, { useState, useEffect, ChangeEvent, FormEvent } from "react";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 import { FormSection } from "./FormSection";
+import type { PlacementFormData } from "../types";
 
-type FormData = {
-  candidateName: string;
-  sstVivza: string;
-  location: string;
-  poCountTotal: number;
-  poCountAMD: string;
-  poCountGGR: string;
-  poCountLKO: string;
-  placementOfferID: string;
-  personalPhone: string;
-  email: string;
-  fullAddress: string;
-  jobType: string;
-  positionApplied: string;
-  jobLocation: string;
-  endClient: string;
-  vendorName: string;
-  vendorTitle: string;
-  vendorDirect: string;
-  vendorEmail: string;
-  rate: string;
-  signupDate: string;
-  training: string;
-  trainingDoneDate: string;
-  joiningDate: string;
-  marketingStart: string;
-  marketingEnd: string;
-  salesLeadBy: string;
-  salesPerson: string;
-  salesTeamLead: string;
-  salesManager: string;
-  supportBy: string;
-  interviewTeamLead: string;
-  interviewManager: string;
-  applicationBy: string;
-  recruiterName: string;
-  marketingTeamLead: string;
-  marketingManager: string;
-  agreementPercent: string;
-  agreementMonths: string;
-  remarks: string;
-};
 
 const fieldLabels: Record<string, string> = {
+  id: "ID",
   candidateName: "Candidate Name",
   sstVivza: "SST/Vivza",
   location: "Location",
@@ -90,7 +50,8 @@ const fieldLabels: Record<string, string> = {
 };
 
 const POForm: React.FC = () => {
-  const initialState: FormData = {
+  const initialState: PlacementFormData = {
+    id: "",
     candidateName: "",
     sstVivza: "",
     location: "",
@@ -133,10 +94,10 @@ const POForm: React.FC = () => {
     remarks: "",
   };
 
-  const [data, setData] = useState<FormData>({ ...initialState });
+  const [data, setData] = useState<PlacementFormData>({ ...initialState });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [showPopup, setShowPopup] = useState(false);
-  const [submittedData, setSubmittedData] = useState<FormData | null>(null);
+  const [submittedData, setSubmittedData] = useState<PlacementFormData | null>(null);
 
   const generatePOID = () => {
     const today = new Date();
@@ -148,7 +109,8 @@ const POForm: React.FC = () => {
   };
 
   useEffect(() => {
-    setData((d) => ({ ...d, placementOfferID: generatePOID() }));
+    const id = generatePOID();
+    setData((d) => ({ ...d, placementOfferID: id, id }));
   }, []);
 
   const formatCandidateName = (value: string) =>
@@ -229,7 +191,8 @@ const POForm: React.FC = () => {
       setSubmittedData(data);
       setShowPopup(true);
       localStorage.setItem("placementOfferForm", JSON.stringify(data));
-      setData({ ...initialState, placementOfferID: generatePOID() });
+      const id = generatePOID();
+      setData({ ...initialState, placementOfferID: id, id });
       setErrors({});
     }
   };
@@ -270,7 +233,7 @@ const POForm: React.FC = () => {
   // Custom input renderer
   const renderInput = (
     label: string,
-    name: keyof FormData,
+    name: keyof PlacementFormData,
     type = "text",
     isTextArea = false,
     options?: string[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,50 @@ export interface Candidate extends FormData {
   updatedAt: string;
 }
 
+export interface PlacementFormData {
+  id: string;
+  candidateName: string;
+  sstVivza: string;
+  location: string;
+  poCountTotal: number;
+  poCountAMD: string;
+  poCountGGR: string;
+  poCountLKO: string;
+  placementOfferID: string;
+  personalPhone: string;
+  email: string;
+  fullAddress: string;
+  jobType: string;
+  positionApplied: string;
+  jobLocation: string;
+  endClient: string;
+  vendorName: string;
+  vendorTitle: string;
+  vendorDirect: string;
+  vendorEmail: string;
+  rate: string;
+  signupDate: string;
+  training: string;
+  trainingDoneDate: string;
+  joiningDate: string;
+  marketingStart: string;
+  marketingEnd: string;
+  salesLeadBy: string;
+  salesPerson: string;
+  salesTeamLead: string;
+  salesManager: string;
+  supportBy: string;
+  interviewTeamLead: string;
+  interviewManager: string;
+  applicationBy: string;
+  recruiterName: string;
+  marketingTeamLead: string;
+  marketingManager: string;
+  agreementPercent: string;
+  agreementMonths: string;
+  remarks: string;
+}
+
 export interface AutocompleteData {
   names: Set<string>;
   genders: Set<string>;


### PR DESCRIPTION
## Summary
- define `PlacementFormData` interface with `id` property in `types.ts`
- use `PlacementFormData` in `PlacementForm` component
- generate and reset the form's `id` alongside `placementOfferID`

## Testing
- `npm run lint` *(fails: no-explicit-any, no-unused-vars, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688a960120c0832687a2f073ca342bd3