### PR TITLE
feat: add placement form tab navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react"
 import { Plus, CalendarClock } from "lucide-react"
 import CandidateFormContainer from "./components/CandidateFormContainer"
 import CandidateTimeline from "./components/CandidateTimeline"
+import PlacementForm from "./components/PlacementForm"
 import { DetailModal } from "./components/DetailModal"
 import { LoadingOverlay } from "./components/LoadingOverlay"
 import { TabNavigation } from "./components/TabNavigation"
@@ -263,7 +264,7 @@ export default function App() {
                 />
               </div>
             </div>
-          ) : (
+          ) : activeTab === "scheduled" ? (
             <div className="animate-in fade-in-50 duration-500">
               {candidates.length === 0 ? (
                 <div className="flex items-center justify-center min-h-[50vh]">
@@ -291,6 +292,10 @@ export default function App() {
                   />
                 </div>
               )}
+            </div>
+          ) : (
+            <div className="animate-in fade-in-50 duration-500">
+              <PlacementForm />
             </div>
           )}
         </div>

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type { LucideIcon } from "lucide-react"
+import { FileText } from "lucide-react"
 import type { TabId } from "../types"
 
 interface Tab {
@@ -18,6 +19,15 @@ interface TabNavigationProps {
 }
 
 export function TabNavigation({ tabs, activeTab, onChange }: TabNavigationProps) {
+  const allTabs: Tab[] = [
+    ...tabs,
+    {
+      id: "placement",
+      label: "Placement Form",
+      icon: FileText,
+    },
+  ]
+
   return (
     <div className="w-full">
       {/* Mobile Select Dropdown */}
@@ -30,7 +40,7 @@ export function TabNavigation({ tabs, activeTab, onChange }: TabNavigationProps)
             value={activeTab}
             onChange={(e) => onChange(e.target.value as TabId)}
           >
-            {tabs.map((tab) => (
+            {allTabs.map((tab) => (
               <option key={tab.id} value={tab.id} className="py-2 bg-gray-800 text-white">
                 {tab.label} {tab.badge ? `(${tab.badge})` : ""}
               </option>
@@ -48,7 +58,7 @@ export function TabNavigation({ tabs, activeTab, onChange }: TabNavigationProps)
       <div className="hidden sm:block">
         <div className="bg-gray-800 rounded-2xl p-1.5 shadow-sm ring-1 ring-gray-700/50">
           <nav className="flex space-x-1" aria-label="Tabs">
-            {tabs.map((tab) => {
+            {allTabs.map((tab) => {
               const Icon = tab.icon
               const isActive = activeTab === tab.id
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type TaskType =
   | 'resumeUnderstanding'
   | 'resumeReview';
 
-export type TabId = 'new' | 'scheduled';
+export type TabId = 'new' | 'scheduled' | 'placement';
 
 export type ToastType = 'success' | 'error' | 'info' | 'warning';
 


### PR DESCRIPTION
## Summary
- append Placement Form tab in navigation
- show PlacementForm component when tab is active
- support new `placement` tab id

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, no-unused-vars, prefer-const)


------
https://chatgpt.com/codex/tasks/task_b_688ab79b55f88326bd49073c93e04940