### PR TITLE
Move support field to interview section

### DIFF
--- a/src/components/PlacementForm.tsx
+++ b/src/components/PlacementForm.tsx
@@ -352,9 +352,9 @@ const POForm: React.FC = () => {
             {renderInput("Sales Person", "salesPerson")}
             {renderInput("Sales Team Lead", "salesTeamLead")}
             {renderInput("Sales Manager", "salesManager")}
-            {renderInput("Support By", "supportBy")}
 
             <h4 className="font-semibold text-gray-200 mt-2">Interview Support</h4>
+            {renderInput("Support By", "supportBy")}
             {renderInput("Interview Team Lead", "interviewTeamLead")}
             {renderInput("Interview Manager", "interviewManager")}
 


### PR DESCRIPTION
## Summary
- Move "Support By" field from Sales subsection to Interview Support subsection in placement form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / unused vars in other files)*

------
https://chatgpt.com/codex/tasks/task_b_688ac6d5d5f88326866e988036e2d8a5