### PR TITLE
Remove Noida from location dropdown

### DIFF
--- a/src/components/PlacementForm.tsx
+++ b/src/components/PlacementForm.tsx
@@ -294,7 +294,6 @@ const POForm: React.FC = () => {
               {renderInput("Location", "location", "text", false, [
                 "Gurgaon",
                 "Ahmedabad",
-                "Noida",
                 "Lucknow",
               ])}
             </div>


### PR DESCRIPTION
## Summary
- remove "Noida" option from PlacementForm location field

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_b_688b92b44df4832688ddd29caf21ec4f