### PR TITLE
fix: omit placement ID from exported PDFs

### DIFF
--- a/src/components/PlacementForm.tsx
+++ b/src/components/PlacementForm.tsx
@@ -327,10 +327,12 @@ const POForm: React.FC = () => {
     if (!submittedData) return;
     const doc = new jsPDF();
     doc.text(submittedData.candidateName || "Submitted Data", 14, 15);
-    const tableData = Object.entries(submittedData).map(([key, value]) => [
-      fieldLabels[key] || key,
-      value || "N/A",
-    ]);
+
+    const excludeKeys = new Set(["placementOfferID", "id"]);
+    const tableData = Object.entries(submittedData)
+      .filter(([key]) => !excludeKeys.has(key))
+      .map(([key, value]) => [fieldLabels[key] || key, value || "N/A"]);
+
     autoTable(doc, {
       head: [["Field", "Value"]],
       body: tableData,


### PR DESCRIPTION
## Summary
- exclude placement ID and internal ID from generated PDF downloads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 6 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6890df732df88326af8d43a0c46a8e7f