### PR TITLE
Group vendor details in popup

### DIFF
--- a/src/components/PlacementForm.tsx
+++ b/src/components/PlacementForm.tsx
@@ -63,6 +63,16 @@ const groupedSections: {
     ],
   },
   {
+    heading: "Vendor",
+    fields: [
+      { label: "Name", key: "vendorName" },
+      { label: "Title", key: "vendorTitle" },
+      { label: "Direct", key: "vendorDirect" },
+      { label: "Email", key: "vendorEmail" },
+      { label: "Rate", key: "rate" },
+    ],
+  },
+  {
     heading: "Sales",
     fields: [
       { label: "Lead By", key: "salesLeadBy" },


### PR DESCRIPTION
## Summary
- group vendor data in PlacementForm popup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 6 errors, 2 warnings)*
- `npx eslint src/components/PlacementForm.tsx`


------
https://chatgpt.com/codex/tasks/task_b_6890f40e0eb48326a78e89cd5f3637ab