### PR TITLE
Use numeric types for numeric fields in placement form

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,9 +53,9 @@ export interface PlacementFormData {
   sstVivza: string;
   location: string;
   poCountTotal: number;
-  poCountAMD: string;
-  poCountGGR: string;
-  poCountLKO: string;
+  poCountAMD: number | '';
+  poCountGGR: number | '';
+  poCountLKO: number | '';
   placementOfferID: string;
   personalPhone: string;
   email: string;
@@ -68,7 +68,7 @@ export interface PlacementFormData {
   vendorTitle: string;
   vendorDirect: string;
   vendorEmail: string;
-  rate: string;
+  rate: number | '';
   signupDate: string;
   training: string;
   trainingDoneDate: string;
@@ -86,8 +86,8 @@ export interface PlacementFormData {
   recruiterName: string;
   marketingTeamLead: string;
   marketingManager: string;
-  agreementPercent: string;
-  agreementMonths: string;
+  agreementPercent: number | '';
+  agreementMonths: number | '';
   remarks: string;
 }
 


### PR DESCRIPTION
## Summary
- type PO counts, rate, and agreement fields as `number | ''`
- handle numeric input as numbers and keep zero values when displaying

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars elsewhere)*
- `npx eslint src/components/PlacementForm.tsx src/types.ts`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68924eb0f3a08326ac14b9c8617f3777