### PR TITLE
refactor: type numeric fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,9 +53,9 @@ export interface PlacementFormData {
   sstVivza: string;
   location: string;
   poCountTotal: number;
-  poCountAMD: string;
-  poCountGGR: string;
-  poCountLKO: string;
+  poCountAMD: number | '';
+  poCountGGR: number | '';
+  poCountLKO: number | '';
   placementOfferID: string;
   personalPhone: string;
   email: string;
@@ -68,7 +68,7 @@ export interface PlacementFormData {
   vendorTitle: string;
   vendorDirect: string;
   vendorEmail: string;
-  rate: string;
+  rate: number | '';
   signupDate: string;
   training: string;
   trainingDoneDate: string;
@@ -86,8 +86,8 @@ export interface PlacementFormData {
   recruiterName: string;
   marketingTeamLead: string;
   marketingManager: string;
-  agreementPercent: string;
-  agreementMonths: string;
+  agreementPercent: number | '';
+  agreementMonths: number | '';
   remarks: string;
 }
 


### PR DESCRIPTION
## Summary
- type numeric PlacementFormData fields as `number | ''`
- convert numeric inputs to numbers in form state and PDF/table output

## Testing
- `npm run lint` *(fails: Unexpected any in AutocompleteInput.tsx, CandidateTimeline.tsx; unused vars and other issues)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68927bbdef188326966f71042b934b99