### PR TITLE
refactor: use numeric types for placement fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,9 +53,9 @@ export interface PlacementFormData {
   sstVivza: string;
   location: string;
   poCountTotal: number;
-  poCountAMD: string;
-  poCountGGR: string;
-  poCountLKO: string;
+  poCountAMD: number | "";
+  poCountGGR: number | "";
+  poCountLKO: number | "";
   placementOfferID: string;
   personalPhone: string;
   email: string;
@@ -68,7 +68,7 @@ export interface PlacementFormData {
   vendorTitle: string;
   vendorDirect: string;
   vendorEmail: string;
-  rate: string;
+  rate: number | "";
   signupDate: string;
   training: string;
   trainingDoneDate: string;
@@ -86,8 +86,8 @@ export interface PlacementFormData {
   recruiterName: string;
   marketingTeamLead: string;
   marketingManager: string;
-  agreementPercent: string;
-  agreementMonths: string;
+  agreementPercent: number | "";
+  agreementMonths: number | "";
   remarks: string;
 }
 


### PR DESCRIPTION
## Summary
- model numeric placement fields as `number | ''` for accuracy
- parse and validate numeric fields as numbers within PlacementForm
- use numeric inputs for rate and agreement fields

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type, menuOpenId unused)*

------
https://chatgpt.com/codex/tasks/task_b_689297111f688326be03585cbfa0be79